### PR TITLE
modify normalization func with in-place operations

### DIFF
--- a/transcriptomic_clustering/normalize.py
+++ b/transcriptomic_clustering/normalize.py
@@ -36,7 +36,8 @@ def normalize_cell_expresions(cell_expressions: ad.AnnData):
     # log
     if issparse(cell_expressions.X):
         if cell_expressions.X.getformat() == 'csr':
-            cell_expressions.X = csr_matrix.log1p(cell_expressions.X)/np.log(2.0)
+            sc.pp.log1p(cell_expressions)
+            cell_expressions.X /= np.log(2.0)
         else:
             raise ValueError("Unsupported format for cell_expression matrix. Must be in CSR or dense format")
     else:


### PR DESCRIPTION
This is quick fix to allow normalization run with an inplace operation to save pretty much memory in running.

Test results for tasic 2016 data;

- Before

```
Line #    Mem usage    Increment  Occurences   Line Contents
============================================================
    11  159.676 MiB  159.676 MiB           1   @profile
    12                                         def normalize_cell_expresions():
    13                                         
    14  281.793 MiB  122.117 MiB           1       cell_expressions = sc.read_h5ad(filename)
    15                                         
    16                                             # cpm
    17  335.145 MiB   53.352 MiB           1       sc.pp.normalize_total(cell_expressions, target_sum=1e6, inplace=True)
    18                                         
    19                                             # log
    20  335.145 MiB    0.000 MiB           1       if issparse(cell_expressions.X):
    21  335.145 MiB    0.000 MiB           1           if cell_expressions.X.getformat() == 'csr':
    22  707.340 MiB  372.195 MiB           1               cell_expressions.X = csr_matrix.log1p(cell_expressions.X)/np.log(2.0)
    23                                                 else:
    24                                                     raise ValueError("Unsupported format for cell_expression matrix. Must be in CSR or dense format")
    25                                             else:
    26                                                 cell_expressions.X = np.log2(cell_expressions.X+1)
    27                                         
    28  707.340 MiB    0.000 MiB           1       return cell_expressions
```

- After

```
Line #    Mem usage    Increment  Occurences   Line Contents
============================================================
    11  159.688 MiB  159.688 MiB           1   @profile
    12                                         def normalize_cell_expresions():
    13                                         
    14  282.141 MiB  122.453 MiB           1       cell_expressions = sc.read_h5ad(filename)
    15                                         
    16                                             # cpm
    17  335.477 MiB   53.336 MiB           1       sc.pp.normalize_total(cell_expressions, target_sum=1e6, inplace=True)
    18                                         
    19                                             # log
    20  335.477 MiB    0.000 MiB           1       if issparse(cell_expressions.X):
    21  335.477 MiB    0.000 MiB           1           if cell_expressions.X.getformat() == 'csr':
    22                                                     # cell_expressions.X = csr_matrix.log1p(cell_expressions.X)/np.log(2.0)
    23                                                     
    24  335.480 MiB    0.004 MiB           1               sc.pp.log1p(cell_expressions)
    25  335.484 MiB    0.004 MiB           1               cell_expressions.X /= np.log(2.0)
    26                                                     
    27                                                     
    28                                                 else:
    29                                                     raise ValueError("Unsupported format for cell_expression matrix. Must be in CSR or dense format")
    30                                             else:
    31                                                 cell_expressions.X = np.log2(cell_expressions.X+1)
    32                                         
    33  335.484 MiB    0.000 MiB           1       return cell_expressions
```

