### PR TITLE
Bugfix/negative cluster fix

### DIFF
--- a/tests/test_louvain.py
+++ b/tests/test_louvain.py
@@ -3,6 +3,10 @@ import pytest
 import csv
 import os
 
+from mock import patch
+from unittest.mock import MagicMock
+
+import transcriptomic_clustering as tc
 from transcriptomic_clustering.louvain import cluster_louvain
 
 DIR_NAME = os.path.dirname(__file__)
@@ -47,3 +51,11 @@ def test_adata_inplace(pca_data, r_data):
             error_count += 1
     error = error_count / float(len(r_data))
     assert error < .02
+
+def test_outlier_label_handling():
+    test_adata = MagicMock()
+    test_adata.X = None
+    with patch.object(tc.louvain, 'phenograph', return_value=([-1, 1, -1, 2, -1, 3], None, None)):
+        cluster_by_obs, obs_by_cluster, _, _ = cluster_louvain(test_adata, 4, False)
+    assert cluster_by_obs == [4, 1, 5, 2, 6, 3]
+    assert obs_by_cluster == {1: [1], 4: [0], 5: [2], 2: [3], 6: [4], 3: [5]}

--- a/transcriptomic_clustering/louvain.py
+++ b/transcriptomic_clustering/louvain.py
@@ -50,6 +50,8 @@ def cluster_louvain(
             obs_by_cluster[max_cluster + 1] = [obs]
             cluster_by_obs[obs] = max_cluster + 1
             max_cluster += 1
+        
+        del obs_by_cluster[-1]
 
     if annotate:
         adata.obs['pheno_louvain'] = cluster_by_obs


### PR DESCRIPTION
This bugfix repairs an issue where cluster outliers were all grouped under cluster label -1 in the output of cluster_louvain. The PR includes a change to reassign outlier label observations to unique cluster labels (for easier cluster merging), and a unit test confirming this behavior on the outlier label in cluster_louvain outputs.