### PR TITLE
Updates cluster similarity calculation to use dataframe of cluster means

### DIFF
--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -63,6 +63,25 @@ def clusters():
 
     return cluster_means, cluster_assignments
 
+@pytest.fixture
+def df_clusters():
+    cluster_assignments = {
+        '11': [0, 3, 5, 9],
+        2: [1, 2, 6],
+        '32': [4, 7],
+        4: [8]
+    }
+
+    cluster_means = pd.DataFrame(
+        np.array([[3., 1.5, 4.],
+                  [3., 4., 2.],
+                  [3., 0.5, 3.],
+                  [0., 0., 7.]]),
+        index = ['11', 2, '32', 4]
+    )
+
+    return cluster_means, cluster_assignments
+
 
 def test_get_cluster_means(adata, clusters):
 
@@ -125,9 +144,9 @@ def test_pdist_normalized():
     assert np.array_equal(expected_similarity, obtained_similarity)
 
 
-def test_find_most_similar(clusters):
+def test_find_most_similar(df_clusters):
 
-    cluster_means, cluster_assignments = clusters
+    cluster_means, cluster_assignments = df_clusters
     group_rows = ['32', 4]
     group_cols = ['11', 2, '32', 4]
 
@@ -183,9 +202,9 @@ def test_on_tasic_clusters(tasic_reduced_dim_adata):
         np.allclose(cluster_means[k], expected_cluster_means[k], rtol=1e-6)
 
 
-def test_calculate_similarity(clusters):
+def test_calculate_similarity(df_clusters):
 
-    cluster_means, cluster_assignments = clusters
+    cluster_means, cluster_assignments = df_clusters
 
     group_rows = ['32', 4]
     group_cols = ['11', 2, '32', 4]

--- a/transcriptomic_clustering/merging.py
+++ b/transcriptomic_clustering/merging.py
@@ -104,7 +104,7 @@ def pdist_normalized(
 
 
 def calculate_similarity(
-        cluster_means: Dict[Any, np.ndarray],
+        cluster_means: pd.DataFrame,
         group_rows: List[Any],
         group_cols: List[Any]
 ) -> pd.DataFrame:
@@ -117,7 +117,7 @@ def calculate_similarity(
     Parameters
     ----------
     cluster_means:
-        map of cluster label to cluster means
+        Dataframe of cluster means with cluster labels as index
     group_rows:
         cluster group with clusters being merged
     group_cols:
@@ -129,13 +129,11 @@ def calculate_similarity(
     """
 
     cluster_labels_subset = set(group_rows + group_cols)
-    cluster_means_subset = {k: cluster_means[k] for k in cluster_labels_subset}
-    means = np.array(list(cluster_means_subset.values()))
+    means = cluster_means.loc[cluster_labels_subset]
     n_clusters, n_vars = means.shape
 
     if n_vars > 2:
-        similarity_df = pd.DataFrame(cluster_means,
-                                     columns=cluster_labels_subset).corr()
+        similarity_df = means.T.corr()
     else:
         similarity = pdist_normalized(means)
         similarity_df = pd.DataFrame(similarity,
@@ -209,8 +207,9 @@ def merge_small_clusters(
     small_cluster_labels = find_small_clusters(cluster_assignments, min_size=min_size)
 
     while small_cluster_labels:
+        cluster_means_df = pd.DataFrame(np.vstack(list(cluster_means.values())), index=cluster_means.keys())
         similarity_small_to_all_df = calculate_similarity(
-            cluster_means,
+            cluster_means_df,
             group_rows=small_cluster_labels,
             group_cols=all_cluster_labels)
 


### PR DESCRIPTION
Small PR to help parallelize conversion effort from cluster means dictionaries to cluster means dataframes. Changes calculate_similarity to take a dataframe as cluster means input, updates call to calculate_similarity in merge_small_clusters, and all corresponding unit tests.