### PR TITLE
Add nearest neighbor calculation for merging

### DIFF
--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -220,13 +220,13 @@ def test_calculate_similarity(df_clusters):
     obtained_similarity.equals(expected_similarity)
 
 
-def test_get_k_nearest_neighbors(df_clusters):
+def test_get_k_nearest_clusters(df_clusters):
 
     cluster_means, _ = df_clusters
 
     expected_nns = [('11', 4), ('11', '32'), (2, '32'), (2, 4), ('32', 4)]
 
-    knns = merging.get_k_nearest_neighbors(cluster_means, k=2)
+    knns = merging.get_k_nearest_clusters(cluster_means, k=2)
 
     assert len(expected_nns) == len(knns)
     for n in expected_nns:

--- a/transcriptomic_clustering/merging.py
+++ b/transcriptomic_clustering/merging.py
@@ -225,12 +225,12 @@ def merge_small_clusters(
         all_cluster_labels = list(cluster_assignments.keys())
 
 
-def get_k_nearest_neighbors(
+def get_k_nearest_clusters(
         cluster_means: pd.DataFrame,
         k: Optional[int] = 2
 ) -> List[Tuple[int, int]]:
     """
-    Get k nearest neighbors of clusters
+    Get k nearest neighbors for each cluster
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- Small PR that adds a k nearest neighbor calculation on the cluster means
- k is an optional param and defaults to 2
- the output is deterministic, but the sorter is not due to the use of a set to remove duplicate values
  - This could be avoided if do sorting on the list/set when removing duplicates, but requires the test cluster_mean object to only have either str or int as cluster labels.
- Verified the test input against R and it is equivalent.