### PR TITLE
Ignore divide by zero warning in log10 when computing de scores

### DIFF
--- a/transcriptomic_clustering/de_ebayes.py
+++ b/transcriptomic_clustering/de_ebayes.py
@@ -205,7 +205,7 @@ def de_pairs_ebayes(
             cl2_size=cl_size[cluster_b],
             **de_thresholds
         )
-        up_score = calc_de_score(de_pair_up['p_adj'])
+        up_score = calc_de_score(de_pair_up['p_adj'].values)
 
         de_pair_down = filter_gene_stats(
             de_stats=de_pair_stats,
@@ -214,7 +214,7 @@ def de_pairs_ebayes(
             cl2_size=cl_size[cluster_b],
             **de_thresholds
         )
-        down_score = calc_de_score(de_pair_down['p_adj'])
+        down_score = calc_de_score(de_pair_down['p_adj'].values)
 
         de_pairs[(cluster_a, cluster_b)] = {
             'score': up_score + down_score,

--- a/transcriptomic_clustering/diff_expression.py
+++ b/transcriptomic_clustering/diff_expression.py
@@ -156,7 +156,7 @@ def filter_gene_stats(
         threshold for proportion of cells expressing each gene in the first cluster
     q2_thresh:
         threshold for proportion of cells expressing each gene in the second cluster
-    min_cell_thresh:
+    cluster_size_thresh:
         threshold for min number of cells in cluster
     qdiff_thresh:
         threshold for qdiff
@@ -238,7 +238,8 @@ def calc_de_score(
     -------
     differential expression score
     """
-    de_score = np.sum(-np.log10(padj)) if len(padj) else 0
+    with np.errstate(divide='ignore'): # allow de_score = inf for padj = 0
+        de_score = np.sum(-np.log10(padj)) if len(padj) else 0
 
     return de_score
 
@@ -279,7 +280,7 @@ def de_pairs_chisq(
             cl2_size=cl_size[second_cluster],
             **de_thresholds
         )
-        up_score = calc_de_score(de_pair_up['p_adj'])
+        up_score = calc_de_score(de_pair_up['p_adj'].values)
 
         de_pair_down = filter_gene_stats(
             de_stats=de_pair_stats,
@@ -288,7 +289,7 @@ def de_pairs_chisq(
             cl2_size=cl_size[second_cluster],
             **de_thresholds
         )
-        down_score = calc_de_score(de_pair_down['p_adj'])
+        down_score = calc_de_score(de_pair_down['p_adj'].values)
 
         de_pairs[pair] = {
             'score': up_score + down_score,


### PR DESCRIPTION
Avoid warning inside the de_score function
" RuntimeWarning: divide by zero encountered in log10"
it results from computing log10(pval) when pval=0 returning an inf. This is not a problem because we are just thresholding the de_scores.
The warning is annoying because it appears multiple times in the notebook.