### PR TITLE
Bugfix/seg fault

### DIFF
--- a/transcriptomic_clustering/cluster_means.py
+++ b/transcriptomic_clustering/cluster_means.py
@@ -123,7 +123,7 @@ def get_cluster_means_backed(
     n_clusters = len(cluster_assignments.keys())
 
     itemsize = adata.X.dtype.itemsize
-    process_memory_estimate = (n_cells * n_genes) * itemsize / (1024 ** 3)
+    process_memory_estimate = 2 * (n_cells * n_genes) * itemsize / (1024 ** 3)
     output_memory_estimate = 2 * (n_clusters * n_genes) * itemsize / (1024 ** 3)
     
     estimated_chunk_size = tc.memory.estimate_chunk_size(


### PR DESCRIPTION
**Problem:**
were were getting Seg fault error when merging clusters on large dataset.
Segfault was happening when computing cluster means on full data.

**Solution:**
Increase process memory by factor 2 solved the issue 
Also: Added exception if allotted memory is less than used by process 

**Validation:**
Successful run result is in the slide deck