### PR TITLE
Bugfix/non deterministic

### DIFF
--- a/transcriptomic_clustering/pca.py
+++ b/transcriptomic_clustering/pca.py
@@ -90,7 +90,7 @@ def pca(
         # random sample
         if cell_select > adata.n_obs:
             cell_select = adata.n_obs
-        cell_mask = np.random.choice(adata.n_obs, cell_select, replace=False)
+        cell_mask = random_state.choice(adata.n_obs, cell_select, replace=False)
         cell_mask.sort()
     else:
         cell_mask = cell_select


### PR DESCRIPTION
Problem:
Address #109
Found that the culprit is PCA's cell cell selector. Which was called without using provided Random State 
Solution:
Change to using RandomState.choice that will make selection with the given random state
Of course, if random_state is not provided then PCA result will not be reproducible.
Validation:
Running pca with a given random_state in notebook produces reproducing result:
```python
(components, explained_variance_ratio, explained_variance, means) = \
    tc.pca(normalized_adata, n_comps=25, cell_select=1000, use_highly_variable=True, svd_solver='arpack',random_state=2333)
```
