### PR TITLE
Add example for selecting a subset from a backed adata

### DIFF
--- a/docs/notebooks/demo_060121.ipynb
+++ b/docs/notebooks/demo_060121.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "yellow-earthquake",
    "metadata": {},
    "outputs": [
@@ -76,7 +76,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "processing: 100%|██████████| 1/1 [00:00<00:00,  1.14it/s]"
+      "processing: 100%|██████████| 1/1 [00:00<00:00,  1.10it/s]"
      ]
     },
     {
@@ -109,17 +109,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 5,
    "id": "legal-background",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "5.1472320556640625"
+       "3.620655059814453"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 6,
    "id": "framed-webcam",
    "metadata": {},
    "outputs": [
@@ -139,8 +139,8 @@
      "output_type": "stream",
      "text": [
       "              total        used        free      shared  buff/cache   available\r\n",
-      "Mem:           15Gi       9.0Gi       3.8Gi       880Mi       2.6Gi       5.1Gi\r\n",
-      "Swap:         2.0Gi       1.8Gi       250Mi\r\n"
+      "Mem:           15Gi        10Gi       504Mi       1.3Gi       4.7Gi       3.6Gi\r\n",
+      "Swap:         2.0Gi       1.5Gi       545Mi\r\n"
      ]
     }
    ],
@@ -150,17 +150,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 7,
    "id": "fifty-payday",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.03861083984375002"
+       "0.04756774902343752"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 8,
    "id": "frozen-banner",
    "metadata": {},
    "outputs": [
@@ -180,7 +180,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "processing: 100%|██████████| 8/8 [00:01<00:00,  6.26it/s]"
+      "processing: 100%|██████████| 6/6 [00:01<00:00,  5.23it/s]"
      ]
     },
     {
@@ -206,12 +206,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 21,
    "id": "alpha-cooper",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AnnData object with n_obs × n_vars = 999 × 24057 backed at 'data/normalized_subset.h5ad'\n",
+      "    var: 'highly_variable'\n",
+      "    uns: 'hvg'\n"
+     ]
+    }
+   ],
    "source": [
-    "my_normalized_adata = normalized_adata[1:1000,:]"
+    "# if wanting to work with a subset of data in backed mode (here choosing the first 1000 cells):\n",
+    "normalized_adata = normalized_adata[:1000,:].copy(filename='./data/normalized_subset.h5ad')\n",
+    "print(normalized_adata)"
    ]
   },
   {
@@ -227,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 18,
    "id": "1fde50fb",
    "metadata": {},
    "outputs": [
@@ -235,7 +247,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AnnData object with n_obs × n_vars = 1809 × 24057 backed at 'data/normalized16.h5ad'\n",
+      "AnnData object with n_obs × n_vars = 999 × 24057 backed at 'data/normalized_subset.h5ad'\n",
       "    var: 'highly_variable'\n",
       "    uns: 'hvg'\n"
      ]
@@ -259,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 19,
    "id": "caroline-indonesia",
    "metadata": {},
    "outputs": [
@@ -267,7 +279,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-07-14 23:09:48,849 root         WARNING  Ignoring svd_solver, using IncrementalPCA\n"
+      "2021-07-23 16:19:25,832 root         WARNING  Ignoring svd_solver, using IncrementalPCA\n"
      ]
     },
     {
@@ -418,7 +430,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0d929b8f",
    "metadata": {},


### PR DESCRIPTION
**Problem:**
View of backed data does not allow adding annotations.
For example something like this would work for AnnData and View of AnnData in memory:
`normalized_adata.uns['hvg']={"flavour":"hicat"}`
but this fails for a View of backed data

**Solution:**
Explain users how to use AnnData when working with the subset of backed data by adding to the notebook the following: 

```python
# if wanting to work with a subset of data in backed mode (here choosing the first 1000 cells):
normalized_adata = normalized_adata[:1000,:].copy(filename='./data/normalized_subset.h5ad')
print(normalized_adata)

```
apparently this is by design. See the very end of the [anndata blog post](https://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/).
**Validation:**
HVG on a subset done this way does not fail:
![image](https://user-images.githubusercontent.com/38869851/126850132-d064a45c-865f-4576-bb64-4be961bf5c91.png)

**Note:**
if we follow this route, we should also add nice exception message if users do pass View to functions. Not sure how many modules are affected by this. 