### PR TITLE
Modified the final_merge function

### DIFF
--- a/transcriptomic_clustering/__init__.py
+++ b/transcriptomic_clustering/__init__.py
@@ -29,5 +29,6 @@ from .hierarchical_sorting import hclust
 from .cluster_means import get_cluster_means
 from .merging import merge_clusters
 from .diff_expression import de_pairs_chisq, vec_chisq_test
-from .de_ebayes import de_pairs_ebayes
+from .de_ebayes import de_pairs_ebayes, de_pairs_ebayes_parallel
 from .merging import merge_clusters
+from .final_merging import final_merge

--- a/transcriptomic_clustering/final_merging.py
+++ b/transcriptomic_clustering/final_merging.py
@@ -1,4 +1,4 @@
-fromt typing import Optional, Dict, Set, List, Any
+from typing import Optional, Dict, Set, List, Any
 from collections import defaultdict
 from dataclasses import dataclass, field
 
@@ -13,7 +13,8 @@ from transcriptomic_clustering.iterative_clustering import (
     build_cluster_dict, summarize_final_clusters
 )
 
-
+import logging
+import time
 logger = logging.getLogger(__name__)
 
 
@@ -25,6 +26,7 @@ class FinalMergeKwargs:
     filter_known_modes_kwargs: Dict = field(default_factory = lambda: ({}))
     project_kwargs: Dict = field(default_factory = lambda: ({}))
     merge_clusters_kwargs: Dict = field(default_factory = lambda: ({}))
+    latent_kwargs: Dict = field(default_factory = lambda: ({}))
 
 
 def sample_clusters(
@@ -38,7 +40,10 @@ def sample_clusters(
 
     Parameters
     ----------
-    Adata 
+    adata
+        AnnData object
+    cluster_dict
+        Dictionary of cluster assignments. values are lists of cell names 
 
     Returns
     -------
@@ -46,13 +51,15 @@ def sample_clusters(
     """
 
     rng = default_rng(random_seed)
-    cell_samples = []
+    cell_samples_ids = []
     for k, v in cluster_dict.items():
         if len(v) > n_samples_per_clust:
             choices = rng.choice(v, size=(n_samples_per_clust,))
         else:
             choices = v
-        cell_samples.extend(choices)
+        cell_samples_ids.extend(choices)
+    
+    cell_samples = adata.obs_names[cell_samples_ids]
 
     cell_mask = pd.Series(
         index=adata.obs.index,
@@ -62,112 +69,151 @@ def sample_clusters(
     return cell_mask
 
 
+def _cluster_obs_dict_to_list(obs_by_cluster: Dict[int, List[int]]) -> List[int]:
+    """
+    Convert a dictionary of cluster assignments to a list of cluster assignments
+    """
+    # Find the total number of observations
+    max_index = max(max(indices) for indices in obs_by_cluster.values())
+
+    # Initialize the list of clusters with None (or some other default value)
+    cluster_by_obs = [None] * (max_index + 1)
+
+    # Fill in the list with the corresponding cluster for each observation
+    for cluster, cell_ids in obs_by_cluster.items():
+        for obs in cell_ids:
+            cluster_by_obs[obs] = cluster
+
+    return cluster_by_obs
+
+
 def final_merge(
         adata: ad.AnnData,
-        cluster_assignments: pd.Series,
+        cluster_assignments: List,
         marker_genes: Set,
         n_samples_per_clust: int = 20,
         random_seed: Optional[int]=None,
+        n_jobs: Optional[int] = 1,
+        return_markers_df: Optional[bool] = False,
         final_merge_kwargs: FinalMergeKwargs = FinalMergeKwargs(),
 ) -> pd.DataFrame:
     """
     Runs a final merging step on cluster assignment results
+    Step1: Using a pre-defined latent space or compute PCA as below:
     * Do PCA on random sample of cells per cluster and selected marker genes
     * Filter PCA results to select top eigenvectors
     * Project to reduced space
     * remove known eigen vector
-    * Do differential expression merge
+   Step2: Do differential expression merge
 
     Parameters
     ----------
+    adata
+        AnnData object
+    cluster_assignments
+        List of arrays of cell ids, one array per cluster. This is the result returned by onestep_clust/iter_clust
     
     """
 
-    # Quick data rearranging for convenience
-    cluster_dict = defaultdict(lambda: [])
-    for cell_name, cl_label in cluster_assignments.iteritems():
-        cluster_dict[row].append(cell_name)
-
-    cell_mask = sample_clusters(
-        adata=adata,
-        cluster_dict=cluster_dict,
-        n_samples_per_clust=n_samples_per_clust,
-        random_seed=random_seed
-    )
-    gene_mask = pd.Series(
-        index=adata.var.index,
-        dtype=bool
-    )
-    gene_mask[markers] = True
-
-    # Do PCA on cell samples and marker genes
-    logger.info('Computing PCA on cell samples and marker genes')
-    tic = time.perf_counter()
-    (components, explained_variance_ratio, explained_variance, means) =  tc.pca(
-        adata,
-        gene_mask=gene_mask,
-        cell_select=cell_mask,
-        random_state=random_seed,
-        **final_merge_kwargs.pca_kwargs
-    )
-    logger.info(f'Computed {components.shape[1]} principal components')
-    toc = time.perf_counter()
-    logger.info(f'PCA Elapsed Time: {toc - tic}')
-
-    # Filter PCA
-    logger.info('Filtering PCA Components')
-    tic = time.perf_counter()
-    components = tc.dimension_reduction.filter_components(
-        components,
-        explained_variance,
-        explained_variance_ratio,
-        **final_merge_kwargs.filter_pcs_kwargs
-    )
-    logger.info(f'Filtered to {components.shape[1]} principal components')
-    toc = time.perf_counter()
-    logger.info(f'Filter PCA Elapsed Time: {toc - tic}')
-
-    # Project
-    logger.info("Projecting into PCA space")
-    tic = time.perf_counter()
-    projected_adata = tc.project(
-        adata, components, means,
-        **final_merge_kwargs.project_kwargs
-    )
-    logger.info(f'Projected Adata Dimensions: {projected_adata.shape}')
-    toc = time.perf_counter()
-    logger.info(f'Projection Elapsed Time: {toc - tic}')
-
-    # Filter Projection
-    #Filter Known Modes
-    if final_merge_kwargs.filter_known_modes_kwargs:
-        logger.info('Filtering Known Modes')
-        tic = time.perf_counter()
-
-        projected_adata = tc.filter_known_modes(
-            projected_adata,
-            **final_merge_kwargs.filter_known_modes_kwargs
-        )
-
-        logger.info(f'Projected Adata Dimensions after Filtering Known Modes: {projected_adata.shape}')
-        toc = time.perf_counter()
-        logger.info(f'Filter Known Modes Elapsed Time: {toc - tic}')
-    else:
-        logger.info('No known modes, skipping Filter Known Modes')
+    obs_by_cluster = defaultdict(lambda: [])
+    for i, cell_ids in enumerate(cluster_assignments):
+        obs_by_cluster[i] = cell_ids
     
+    cluster_by_obs = _cluster_obs_dict_to_list(obs_by_cluster)
+
+    if final_merge_kwargs.latent_kwargs.get("latent_component") is None:
+
+        cell_mask = sample_clusters(
+            adata=adata,
+            cluster_dict=obs_by_cluster,
+            n_samples_per_clust=n_samples_per_clust,
+            random_seed=random_seed
+        )
+        gene_mask = pd.Series(
+            index=adata.var.index,
+            dtype=bool
+        )
+        gene_mask[marker_genes] = True
+
+        # Do PCA on cell samples and marker genes
+        logger.info('Computing PCA on cell samples and marker genes')
+        tic = time.perf_counter()
+        (components, explained_variance_ratio, explained_variance, means) =  tc.pca(
+            adata,
+            gene_mask=gene_mask,
+            cell_select=cell_mask,
+            random_state=random_seed,
+            **final_merge_kwargs.pca_kwargs
+        )
+        logger.info(f'Computed {components.shape[1]} principal components')
+        toc = time.perf_counter()
+        logger.info(f'PCA Elapsed Time: {toc - tic}')
+
+        # Filter PCA
+        logger.info('Filtering PCA Components')
+        tic = time.perf_counter()
+        components = tc.dimension_reduction.filter_components(
+            components,
+            explained_variance,
+            explained_variance_ratio,
+            **final_merge_kwargs.filter_pcs_kwargs
+        )
+        logger.info(f'Filtered to {components.shape[1]} principal components')
+        toc = time.perf_counter()
+        logger.info(f'Filter PCA Elapsed Time: {toc - tic}')
+
+        # Project
+        logger.info("Projecting into PCA space")
+        tic = time.perf_counter()
+        projected_adata = tc.project(
+            adata, components, means,
+            **final_merge_kwargs.project_kwargs
+        )
+        logger.info(f'Projected Adata Dimensions: {projected_adata.shape}')
+        toc = time.perf_counter()
+        logger.info(f'Projection Elapsed Time: {toc - tic}')
+
+        # Filter Projection
+        #Filter Known Modes
+        if final_merge_kwargs.filter_known_modes_kwargs:
+            logger.info('Filtering Known Modes')
+            tic = time.perf_counter()
+
+            projected_adata = tc.filter_known_modes(
+                projected_adata,
+                **final_merge_kwargs.filter_known_modes_kwargs
+            )
+
+            logger.info(f'Projected Adata Dimensions after Filtering Known Modes: {projected_adata.shape}')
+            toc = time.perf_counter()
+            logger.info(f'Filter Known Modes Elapsed Time: {toc - tic}')
+        else:
+            logger.info('No known modes, skipping Filter Known Modes')
+    
+    else:
+        logger.info('Extracting latent dims')
+        tic = time.perf_counter()   
+
+         ## Extract latent dimensions
+        projected_adata = tc.latent_project(adata, **final_merge_kwargs.latent_kwargs)
+
+        toc = time.perf_counter()
+        logger.info(f'Extracting latent dims Elapsed Time: {toc - tic}')
 
     # Merging
     logger.info('Starting Cluster Merging')
     tic = time.perf_counter()
-    cluster_assignments_after_merging = tc.merge_clusters(
+    cluster_assignments_after_merging, markers = tc.merge_clusters(
         adata_norm=adata,
         adata_reduced=projected_adata,
-        cluster_assignments=cluster_dict,
-        cluster_by_obs=cluster_assignments,
+        cluster_assignments=obs_by_cluster,
+        cluster_by_obs=cluster_by_obs,
+        return_markers_df=return_markers_df,
+        n_jobs=n_jobs,
         **final_merge_kwargs.merge_clusters_kwargs
     )
     logger.info(f'Completed Merging')
     toc = time.perf_counter()
     logger.info(f'Merging Elapsed Time: {toc - tic}')
 
-    return cluster_assignments_after_merging
+    return cluster_assignments_after_merging, markers

--- a/transcriptomic_clustering/merging.py
+++ b/transcriptomic_clustering/merging.py
@@ -34,7 +34,9 @@ def merge_clusters(
         k: Optional[int] = 2,
         de_method: Optional[str] = 'ebayes',
         n_markers: Optional[int] = 20,
-        chunk_size: Optional[int] = None
+        chunk_size: Optional[int] = None,
+        return_markers_df: Optional[bool] = False,
+        n_jobs: Optional[int] = 1
 ) -> Tuple[Dict[Any, np.ndarray], Set]:
     """
     Merge clusters based on size and differential gene expression score
@@ -63,6 +65,10 @@ def merge_clusters(
         if 0 or None will skip
     chunk_size:
         number of observations to process in a single chunk
+    return_markers_df:
+        return markers as a dataframe
+    n_jobs:
+        number of jobs to run in parallel
 
     Returns
     -------
@@ -132,7 +138,9 @@ def merge_clusters(
     logger.info(f'Merging DE Elapsed Time: {toc - tic}')
 
     # Select marker genes
-    if n_markers:
+    if return_markers_df is False and n_markers is None:
+        markers = None
+    else:
         logger.info('Starting Marker Selection')
         tic = time.perf_counter()
         markers = select_marker_genes(
@@ -143,12 +151,13 @@ def merge_clusters(
             thresholds=thresholds,
             n_markers=n_markers,
             de_method=de_method,
+            return_markers_df=return_markers_df,
+            n_jobs=n_jobs
         )
         logger.info('Completed Marker Selection')
         toc = time.perf_counter()
         logger.info(f'Marker Selection Elapsed Time: {toc - tic}')
-    else:
-        markers = None
+
 
     return cluster_assignments_merge, markers
 


### PR DESCRIPTION

# Notes on modifying the final_merge function and related functions:

## Summary of the function `final_merge()`
- **Step1**: Performs PCA on subsampled cells (equalily from each cluster) and markers, and projects the whole data into the PCA latent space. PCA takes about 40mins for 330k Splatter cells.
- **Step2**: Call the function `tc.merge_clusters()` to do the merging. This is the same function used in the onestep clustering.

## Bugs in the original final_merging.py
- import time and logging
- line 89: row does not exist/ was not defined

## Issues identified in the final_merging.py
- PCA takes about 40 mins to finish if not using a pre-defined latent space, for 330k Splatter cells of 2200 clusters. This is ok.
- The time consuming part is the marker selection:
  - `merge_clusters()` does 1. merge clusters then 2. compute markers between each pair of clusters using the function `select_marker_genes()` in markers.py
  - `select_marker_genes()` returns markers as a set. it is part of the de_df from `de_pairs_ebayes()` in de_ebayes.py.
  **My question**:
  - Modify `de_pairs_ebayes())` so that it returns the whole de_df, not just the markers as a set? **????? do we want both outputs?**
  - `de_df = tc.de_pairs_ebayes()` is slow. Use multiple CPU cores to speed it up

## Major changes in the original final_merging.py
- Changed the input cluster_assignment to be the direct output from clustering, not a reformatted pd.Series of clusters
- Added the option of using a pre-defined latent space instead of computing PCA
- Added in the option of using multiple cores
- Added in the option of returning the whole de_df instead of just top 20 of up and down genes for each pair of comparison. 

## To accomadate the changes in the final_merging.py, made the following changes as well
- In `de_ebayes.py`, added a function called `de_pairs_ebayes_parallel()`. This function has an argument `n_jobs`.
- In `markers.py`,  modified the function `select_marker_genes()`. 
  - Added two arguments. Added `return_markers_df` to specify if the user wants it to return the whole de_df dataframe instead of a set of markers. Added `n_jobs`. 
  - Changed it to use `de_pairs_ebayes_parallel()` instead of `de_pairs_ebayes()`. *Confirmed it returned the same markers
- In `merging.py`, modified the function `merge_clusters()`. Added the two arguments. Now the logic becomes that `if return_markers_df is False and n_markers is None, marker = None`. Otherwise, it calls the function `select_marker_genes()` to computae pair-wise markers

## Benchmarking on `select_marker_genes()`
| Number of Cells   | Number of Clusters| Runtime: de_pairs_ebayes() | Runtime: de_pairs_ebayes_parallel (n_jobs=1) |
|-------------------|-------------------|----------------------------|----------------------------------------------|
| 78245 (H)         | 71 (onestep)      | 6 minutes 54 seconds       | 6 minutes 37 seconds                         |

### Notes:
- Te modified and original `select_marker_genes()` gave the same set of markers

## Benchmarking on `final_merge()`
* Including steps: PCA/latent + `merge_clusters()` (merging + `select_marker_genes()`)

| Number of Cells   | Number of Clusters| Runtime n_jobs=1      | Runtime n_jobs=30     |
|-------------------|-------------------|-----------------------|-----------------------|
| 78245 (H)         | 71 (onestep)      | 6 minutes 37 seconds  | 33.7 seconds          | 
| 78245 (H)         | 465               | NA                    | 20 minutes 50 seconds |
| 199,250 (MSN)     | 145               | 28 minutes 44 seconds | 7 minutes 58 seconds  |
| 348,411 (Splatter)| 2171              | NA                    | 10 hours 15 minutes   |

### Notes
- All these changes does not change clustering results (confirmed using the hypothalamus data)

